### PR TITLE
add script names to error emails

### DIFF
--- a/R/error_email.R
+++ b/R/error_email.R
@@ -49,7 +49,7 @@ build_error_html <- function(.error) {
 #' @export
 #'
 #' @rdname errors
-email_on_error <- function(.e, recipient = email_to()) {
+email_on_error <- function(.e, recipient = email_to(), .msg = NULL) {
   authorize_gmailr()
 
   email_msg <- build_error_html(.e)
@@ -57,20 +57,20 @@ email_on_error <- function(.e, recipient = email_to()) {
   gmailr::mime() %>%
     gmailr::to(recipient) %>%
     gmailr::from("ser.twitteracct@gmail.com") %>%
-    gmailr::subject(paste("Error in SER code:", Sys.time())) %>%
+    gmailr::subject(paste("Error in SER code:", Sys.time(), .msg)) %>%
     gmailr::html_body(email_msg) %>%
     gmailr::send_message()
 
-  invisible(email_msg)
+  .e
 }
 
 #' @export
 #' @rdname errors
-action_safely <- function(.f) {
+action_safely <- function(.f, .msg = NULL) {
   function(...) {
     tryCatch(
       .f(...),
-      error = email_on_error
+      error = purrr::partial(email_on_error, .msg = .msg)
     )
   }
 }

--- a/inst/scripts/auto_meeting_tweet.R
+++ b/inst/scripts/auto_meeting_tweet.R
@@ -1,5 +1,5 @@
 library(ser)
 
 on_error_email_to(c(gmail("malcolmbarrett"), email("jason_gantenberg", "brown.edu")))
-safe_action_meeting_tweet <- action_safely(action_meeting_tweet)
+safe_action_meeting_tweet <- action_safely(action_meeting_tweet, "(auto_meeting_tweet.R)")
 safe_action_meeting_tweet()

--- a/inst/scripts/auto_tweet.R
+++ b/inst/scripts/auto_tweet.R
@@ -21,7 +21,7 @@ is_tweet_length <- function(.x, n = 280) {
 assignInNamespace("is_tweet_length", is_tweet_length, ns = "rtweet")
 
 on_error_email_to(c(gmail("malcolmbarrett"), email("jason_gantenberg", "brown.edu")))
-safe_action_auto_tweet <- action_safely(action_auto_tweet)
+safe_action_auto_tweet <- action_safely(action_auto_tweet, "(auto_tweet.R)")
 safe_action_auto_tweet()
 
 

--- a/inst/scripts/collect_twitter_data.R
+++ b/inst/scripts/collect_twitter_data.R
@@ -4,5 +4,5 @@ options(gargle_oob_default = TRUE)
 options(gargle_oauth_email = gmail("ser.twitteracct"))
 
 on_error_email_to(c(gmail("malcolmbarrett"), email("jason_gantenberg", "brown.edu")))
-safely_collect_twitter_data <- action_safely(action_collect_twitter_data)
+safely_collect_twitter_data <- action_safely(action_collect_twitter_data, "(collect_twitter_data.R)")
 safely_collect_twitter_data()

--- a/inst/scripts/deploy_dashboard.R
+++ b/inst/scripts/deploy_dashboard.R
@@ -4,5 +4,5 @@ options(gargle_oob_default = TRUE)
 options(gargle_oauth_email = gmail("ser.twitteracct"))
 
 on_error_email_to(c(gmail("malcolmbarrett"), email("jason_gantenberg", "brown.edu")))
-safely_deploy_dashboard <- action_safely(action_deploy_dashboard)
+safely_deploy_dashboard <- action_safely(action_deploy_dashboard, "(deploy_dashboard.R)")
 safely_deploy_dashboard()

--- a/inst/scripts/email_summary.R
+++ b/inst/scripts/email_summary.R
@@ -1,7 +1,7 @@
 library(ser)
 
 on_error_email_to(c(gmail("malcolmbarrett"), email("jason_gantenberg", "brown.edu")))
-safe_action_email_summary <- action_safely(action_email_summary)
+safe_action_email_summary <- action_safely(action_email_summary, "(email_summary.R)")
 send_summary_to <- c(
   gmail("malcolmbarrett"),
   email("Anusha.Vable", "ucsf.edu"),

--- a/inst/scripts/test_auto_tweet.R
+++ b/inst/scripts/test_auto_tweet.R
@@ -20,7 +20,7 @@ is_tweet_length <- function(.x, n = 280) {
 assignInNamespace("is_tweet_length", is_tweet_length, ns = "rtweet")
 
 on_error_email_to(c(gmail("malcolmbarrett")))
-safe_action_auto_tweet <- action_safely(action_auto_tweet)
+safe_action_auto_tweet <- action_safely(action_auto_tweet, "(test_auto_tweet.R)")
 safe_action_auto_tweet()
 
 

--- a/inst/scripts/test_email_error.R
+++ b/inst/scripts/test_email_error.R
@@ -3,5 +3,5 @@ auto_error <- function() {
   stop("this is a test as well")
 }
 on_error_email_to(gmail("malcolmbarrett"))
-safe_auto_error <- action_safely(auto_error)
+safe_auto_error <- action_safely(auto_error, "(test_email_error.R)")
 safe_auto_error()

--- a/inst/scripts/test_email_summary.R
+++ b/inst/scripts/test_email_summary.R
@@ -7,7 +7,7 @@ library(ser)
 
 
 on_error_email_to(gmail("malcolmbarrett"))
-safe_action_email_summary <- action_safely(action_email_summary)
+safe_action_email_summary <- action_safely(action_email_summary, "(test_email_summary.R)")
 send_summary_to <-gmail("malcolmbarrett")
 
 safe_action_email_summary(recipients = send_summary_to)


### PR DESCRIPTION
This PR
* Adds the script name to the on-error email for easier debugging
* Throws another error so GHA also fails