### PR TITLE
fix error in GitHub Actions

### DIFF
--- a/R/auto_tweet.R
+++ b/R/auto_tweet.R
@@ -10,8 +10,8 @@ post_tweet_library <- function(tweet_data = tweet_library,
     )
 
   allow_recurrence_ids <- tweet_data %>%
-    filter(Recurrence == "Yes") %>%
-    pull(id_transform)
+    dplyr::filter(Recurrence == "Yes") %>%
+    dplyr::pull(id_transform)
 
   omit_tweet_ids <- past_tweets[!(omit_tweet_ids %in% allow_recurrence_ids)]
 


### PR DESCRIPTION
Because the `dplyr` library is not loaded, functions need to be referred to as `dplyr:pull()`, for example. The tweet recurrence check code omitted the call to `dplyr`.