### PR TITLE
Change name of SER tweet library

### DIFF
--- a/R/auto_tweet.R
+++ b/R/auto_tweet.R
@@ -101,13 +101,13 @@ action_auto_tweet <- function(twitter_token = ser_token,
 
   # download the existing tweet form entries from google drive
   tweet_library_id <- googledrive::drive_find(
-    pattern = "ser_tweet_library",
+    pattern = "ser_tweetform_library",
     type = "spreadsheet"
   ) %>%
     dplyr::pull(id) %>%
     googledrive::as_id()
   googledrive::drive_download(tweet_library_id, type = "csv", overwrite = TRUE)
-  tweet_library <- readr::read_csv("ser_tweet_library.csv")
+  tweet_library <- readr::read_csv("ser_tweetform_library.csv")
 
   # download tweet history
   tweet_hist_id <- googledrive::drive_find(

--- a/inst/scripts/test_auto_tweet.R
+++ b/inst/scripts/test_auto_tweet.R
@@ -5,6 +5,6 @@ library(ser)
 options(gargle_oob_default = TRUE)
 options(gargle_oauth_email = gmail("ser.twitteracct"))
 
-on_error_email_to(c(gmail("malcolmbarrett")))
+on_error_email_to(c(gmail("jason.gantenberg")))
 safe_action_auto_tweet <- action_safely(action_auto_tweet, "(test_auto_tweet.R)")
 safe_action_auto_tweet(twitter_token = sandbox_token())


### PR DESCRIPTION
Github Actions seems to be picking up an old file ID when searching Drive for ser_tweet_library. Trying to change the filename to see if that will fix the issue of GHA not pulling the Recurring column.